### PR TITLE
Fix failing deletion of the zip file

### DIFF
--- a/root/etc/cont-init.d/98-install-vuetorrent
+++ b/root/etc/cont-init.d/98-install-vuetorrent
@@ -41,7 +41,7 @@ fi
 
 echo "Running installer..."
 
-curl -O -J -L $LATEST_RELEASE && \
+curl --silent -O -J -L $LATEST_RELEASE && \
 unzip vuetorrent.zip -d /
 
 # Remove zip after unpacking

--- a/root/etc/cont-init.d/98-install-vuetorrent
+++ b/root/etc/cont-init.d/98-install-vuetorrent
@@ -45,7 +45,7 @@ curl -O -J -L $LATEST_RELEASE && \
 unzip vuetorrent.zip -d /
 
 # Remove zip after unpacking
-rm /vuetorrent.zip
+rm vuetorrent.zip
 
 echo $TAG > $CURRENT
 


### PR DESCRIPTION
The working directory that the 98-install-vuetorrent is a directory like

> `/run/s6-rc:s6-rc-init:MHiMpf/servicedirs/s6rc-oneshot-runner/`

As a result the `rm /vuetorrent.zip` fails with the error

> rm: cannot remove '/vuetorrent.zip': No such file or directory

This PR removes the leading `/` so the `rm` is relative to the current working directory

Also :

Suppress curl progress bar output

This silences curl's progress bar which renders poorly in logged Docker output.

The interleaved progress bar output looks like this

```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                              Dload  Upload   Total   Spent    Left  Speed
^M  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0^M  0     0    0     0    0     0      0      0 --:--:-- --:--:
-- --:--:--     0^M  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

-------------------------------------
       _         ()
      | |  ___   _    __
      | | / __| | |  /  \
      | | \__ \ | | | () |
      |_| |___/ |_|  \__/


Brought to you by linuxserver.io
-------------------------------------

To support LSIO projects visit:
https://www.linuxserver.io/donate/
-------------------------------------
GID/UID
-------------------------------------

User uid:    1000
User gid:    1000
-------------------------------------

^M  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0^M 50 2336k   50 1173k    0     0   455k      0  0:00:05  0:00:02  0:00:03 1182k^M100 2336k  100 2336k    0     0   780k      0  0:00:02  0:00:02 --:--:-- 1658k
```