### PR TITLE
Improve execution flow and edge case coverage

### DIFF
--- a/root/etc/cont-init.d/98-install-vuetorrent
+++ b/root/etc/cont-init.d/98-install-vuetorrent
@@ -25,27 +25,34 @@ CURRENT=/current_version.txt
 
 DIR=/vuetorrent
 
-if [ -e "$CURRENT" ]; then
+ZIP=vuetorrent.zip
+
+if [ -e $CURRENT ]; then
   echo "$CURRENT exists"
 
-  if [[ `cat $CURRENT` == $TAG ]]; then
+  if [ `cat $CURRENT` == $TAG ] && [ -d $DIR ]; then
     echo "Latest version installed: $TAG. Exiting."
     exit
   fi
 fi
 
-if [ -d "$DIR" ]; then
-  echo "Removing $DIR"
-  rm -rf "$DIR"
-fi
-
 echo "Running installer..."
 
-curl --silent -O -J -L $LATEST_RELEASE && \
-unzip vuetorrent.zip -d /
+HTTP_CODE=$(curl --silent -O -J -L $LATEST_RELEASE --write-out "%{http_code}" "$@")
 
-# Remove zip after unpacking
-rm vuetorrent.zip
+if [ $HTTP_CODE == 404 ]; then
+  echo "Error downloading zip: $LATEST_RELEASE. Exiting."
+  exit
+fi
+
+if [ -d $DIR ] && [ -d $ZIP ]; then
+  echo "Removing $DIR"
+  rm -rf $DIR
+fi
+
+unzip $ZIP -d /
+
+rm $ZIP
 
 echo $TAG > $CURRENT
 


### PR DESCRIPTION
I had some problems when there was a recent botched vuetorrent release. The CI was broken and hadn't built a zip, resulting in the `vuetorrent` dir being deleted and no vuetorrent.zip was downloaded to replace it.

I made this PR to catch that kind of edge case by improving the the mod flow:
- Only remove the existing installation after the zip has downloaded successfully.
- Exiting early if the `current_version` matches latest release _and_ the install directory still exists. Or if the zip download url leads to a 404